### PR TITLE
exit on IKE frag timeout - resp variable scope issue

### DIFF
--- a/cisco_asa.py
+++ b/cisco_asa.py
@@ -435,6 +435,7 @@ try:
 except socket.timeout:
     print("[*] IKE Fragment was dropped indicating the ASA is not vulnerable.")
     timeout = True
+    exit(1)
 #Check for notify payload
 if resp[16] == 41:
     print("[*] Notify Payload found. Printing Notify payload data.")


### PR DESCRIPTION
If SA requests receive Notify responses, the `resp` variable scope is not isolated and will create a false positive on IKE Frag timeout. 

e.g.
```
$ python3 cisco_asa.py <redacted>:500
This tool is used to verify the presence of CVE-2016-1287, an unauthenticated remote code execution vulnerability affecting Cisco's ASA products.
No attempt will be made to execute code, this simply observes behavior of affected versions when malformed fragments are sent to the ASA.
Continue? [y/N]
Y
[*] Sending Initiator Request
[*] Received Response
[-] Invalid SA. Trying another...
[*] Sending Initiator Request
[*] Received Response
[-] Invalid SA. Trying another...
[*] Sending Initiator Request
[*] Received Response
[-] Invalid SA. Trying another...
[*] Sending first fragment
[*] Sending second fragment
[*] IKE Fragment was dropped indicating the ASA is not vulnerable.
[*] Notify Payload found. Printing Notify payload data.
	Next payload: NONE
	Critical bit Not Critical
	Payload length: 8
	Protocol ID: 	SPI Size: 0
	Notify Message Type: Invalid Syntax
	Notification DATA: missing
[+] Notification data is missing. ASA is vulnerable.
00000000: 66 53 54 71 45 49 58 64  00 00 00 00 00 00 00 00  fSTqEIXd........
00000010: 29 20 22 20 00 00 00 00  00 00 00 24 00 00 00 08  ) " .......$....
00000020: 00 00 00 07                                       ....
```

Adding an exit on timeout eliminates the print_notify logic from executing. You could also clear `resp` as an alternate approach. 